### PR TITLE
Enable source code link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -168,65 +168,65 @@ bibtex_bibfiles = ["./references.bib"]
 # https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html
 
 #  Alternative method for linking to code by Osama, not sure which one is better
-# from urllib.parse import quote
-# def linkcode_resolve(domain, info):
-#     if domain != "py":
-#         return None
-#     if not info["module"]:
-#         return None
-#     filename = quote(info["module"].replace(".", "/"))
-#     if not filename.startswith("tests"):
-#         filename = "/" + filename
-#     if "fullname" in info:
-#         anchor = info["fullname"]
-#         anchor = "#:~:text=" + quote(anchor.split(".")[-1])
-#     else:
-#         anchor = ""
-#     result = f"{gh_url}/blob/master/{filename}.py{anchor}"
-#     return result
-
-def linkcode_resolve(domain: str, info: Dict[str, str]) -> Optional[str]:
-    """Determine the URL corresponding to a Python object.
-
-    Parameters
-    ----------
-    domain : str
-        One of 'py', 'c', 'cpp', 'javascript'.
-    info : dict
-        With keys "module" and "fullname".
-
-    Returns
-    -------
-    url : str | None
-        The code URL. If None, no link is added.
-    """
+from urllib.parse import quote
+def linkcode_resolve(domain, info):
     if domain != "py":
-        return None  # only document python objects
-
-    # retrieve pyobject and file
-    try:
-        module = import_module(info["module"])
-        pyobject = module
-        for elt in info["fullname"].split("."):
-            pyobject = getattr(pyobject, elt)
-        fname = inspect.getsourcefile(pyobject).replace("\\", "/")
-    except Exception:
-        # Either the object could not be loaded or the file was not found.
-        # For instance, properties will raise.
         return None
-
-    # retrieve start/stop lines
-    source, start_line = inspect.getsourcelines(pyobject)
-    lines = "L%d-L%d" % (start_line, start_line + len(source) - 1)
-
-    # create URL
-    if "dev" in release:
-        branch = "main"
+    if not info["module"]:
+        return None
+    filename = quote(info["module"].replace(".", "/"))
+    if not filename.startswith("tests"):
+        filename = "/" + filename
+    if "fullname" in info:
+        anchor = info["fullname"]
+        anchor = "#:~:text=" + quote(anchor.split(".")[-1])
     else:
-        return None  # alternatively, link to a maint/version branch
-    fname = fname.rsplit(f"/{package}/")[1]
-    url = f"{gh_url}/blob/{branch}/{package}/{fname}#{lines}"
-    return url
+        anchor = ""
+    result = f"{gh_url}/blob/master/{filename}.py{anchor}"
+    return result
+
+# def linkcode_resolve(domain: str, info: Dict[str, str]) -> Optional[str]:
+#     """Determine the URL corresponding to a Python object.
+
+#     Parameters
+#     ----------
+#     domain : str
+#         One of 'py', 'c', 'cpp', 'javascript'.
+#     info : dict
+#         With keys "module" and "fullname".
+
+#     Returns
+#     -------
+#     url : str | None
+#         The code URL. If None, no link is added.
+#     """
+#     if domain != "py":
+#         return None  # only document python objects
+
+#     # retrieve pyobject and file
+#     try:
+#         module = import_module(info["module"])
+#         pyobject = module
+#         for elt in info["fullname"].split("."):
+#             pyobject = getattr(pyobject, elt)
+#         fname = inspect.getsourcefile(pyobject).replace("\\", "/")
+#     except Exception:
+#         # Either the object could not be loaded or the file was not found.
+#         # For instance, properties will raise.
+#         return None
+
+#     # retrieve start/stop lines
+#     source, start_line = inspect.getsourcelines(pyobject)
+#     lines = "L%d-L%d" % (start_line, start_line + len(source) - 1)
+
+#     # create URL
+#     if "dev" in release:
+#         branch = "main"
+#     else:
+#         return None  # alternatively, link to a maint/version branch
+#     fname = fname.rsplit(f"/{package}/")[1]
+#     url = f"{gh_url}/blob/{branch}/{package}/{fname}#{lines}"
+#     return url
 
 
 # # -- sphinx-gallery ----------------------------------------------------------


### PR DESCRIPTION
The source code is not enabled in the documentation. 

In conf.py I have commented out linkcode_resolve function on line number 188 and un-commented function given on line no 172.
I can see the source code locally. 

Hopefully, it should be enabled on github also. 
